### PR TITLE
Fix: can't subtract times with different time sources

### DIFF
--- a/carma_novatel_driver_wrapper/CMakeLists.txt
+++ b/carma_novatel_driver_wrapper/CMakeLists.txt
@@ -12,18 +12,18 @@ include_directories(
   include
 )
 
-ament_auto_add_library(carma_novatel_driver_wrapper_lib SHARED
+ament_auto_add_library(carma_novatel_wrapper_node SHARED
   src/carma_novatel_driver_wrapper.cpp
 )
 
-ament_auto_add_executable(carma_novatel_wrapper_node src/main.cpp)
+ament_auto_add_executable(carma_novatel_wrapper_node_exec src/main.cpp)
 
-target_link_libraries(carma_novatel_wrapper_node 
- carma_novatel_driver_wrapper_lib
+target_link_libraries(carma_novatel_wrapper_node_exec 
+ carma_novatel_wrapper_node
 )
 
 # Register component
-rclcpp_components_register_nodes(carma_novatel_driver_wrapper_lib "carma_novatel_driver_wrapper::CarmaNovatelDriverWrapper")
+rclcpp_components_register_nodes(carma_novatel_wrapper_node "carma_novatel_driver_wrapper::CarmaNovatelDriverWrapper")
 
 if(BUILD_TESTING)  
   find_package(ament_cmake_gtest REQUIRED)
@@ -37,7 +37,7 @@ if(BUILD_TESTING)
   )
   ament_target_dependencies(test_carma_novatel_driver_wrapper ${dependencies})
   
-  target_link_libraries(test_carma_novatel_driver_wrapper carma_novatel_driver_wrapper_lib)
+  target_link_libraries(test_carma_novatel_driver_wrapper carma_novatel_wrapper_node)
 
 endif()
 

--- a/carma_novatel_driver_wrapper/include/carma_novatel_driver_wrapper/carma_novatel_driver_wrapper.hpp
+++ b/carma_novatel_driver_wrapper/include/carma_novatel_driver_wrapper/carma_novatel_driver_wrapper.hpp
@@ -49,6 +49,8 @@ namespace carma_novatel_driver_wrapper
     ////
     carma_ros2_utils::CallbackReturn handle_on_configure(const rclcpp_lifecycle::State &prev_state);
 
+    carma_ros2_utils::CallbackReturn handle_on_activate(const rclcpp_lifecycle::State &prev_state);
+
     
     std::string get_qualified_name();
 

--- a/carma_novatel_driver_wrapper/launch/carma-novatel-driver-wrapper-launch.py
+++ b/carma_novatel_driver_wrapper/launch/carma-novatel-driver-wrapper-launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
             ComposableNode(
                 package = 'carma_novatel_driver_wrapper',
                 plugin='carma_novatel_driver_wrapper::CarmaNovatelDriverWrapper',
-                name='carma_novatel_driver_wrapper_lib',
+                name='carma_novatel_driver_wrapper_node',
                 extra_arguments=[
                     {'use_intra_process_comms': True},
                     {'--log-level' : log_level}

--- a/carma_novatel_driver_wrapper/src/carma_novatel_driver_wrapper.cpp
+++ b/carma_novatel_driver_wrapper/src/carma_novatel_driver_wrapper.cpp
@@ -101,12 +101,17 @@ namespace carma_novatel_driver_wrapper
 
         fix_fused_pub_ = create_publisher<gps_msgs::msg::GPSFix>("gnss_fix_fused", 10.0);
         
-        timer_ = this->create_wall_timer(std::chrono::milliseconds(config_.timer_callback), 
-        std::bind(&CarmaNovatelDriverWrapper::timerCallback, this));
-
         last_gnss_msg_ = this->now();
         last_imu_msg_ = this->now();
         
+        return CallbackReturn::SUCCESS;
+    }
+
+    carma_ros2_utils::CallbackReturn CarmaNovatelDriverWrapper::handle_on_activate(const rclcpp_lifecycle::State &){
+
+        timer_ = this->create_wall_timer(std::chrono::milliseconds(config_.timer_callback), 
+        std::bind(&CarmaNovatelDriverWrapper::timerCallback, this));
+
         return CallbackReturn::SUCCESS;
     }
 

--- a/carma_novatel_driver_wrapper/src/carma_novatel_driver_wrapper.cpp
+++ b/carma_novatel_driver_wrapper/src/carma_novatel_driver_wrapper.cpp
@@ -101,9 +101,6 @@ namespace carma_novatel_driver_wrapper
 
         fix_fused_pub_ = create_publisher<gps_msgs::msg::GPSFix>("gnss_fix_fused", 10.0);
         
-        last_gnss_msg_ = this->now();
-        last_imu_msg_ = this->now();
-        
         return CallbackReturn::SUCCESS;
     }
 
@@ -111,6 +108,9 @@ namespace carma_novatel_driver_wrapper
 
         timer_ = this->create_wall_timer(std::chrono::milliseconds(config_.timer_callback), 
         std::bind(&CarmaNovatelDriverWrapper::timerCallback, this));
+
+        last_gnss_msg_ = this->now();
+        last_imu_msg_ = this->now();
 
         return CallbackReturn::SUCCESS;
     }

--- a/carma_novatel_driver_wrapper/src/carma_novatel_driver_wrapper.cpp
+++ b/carma_novatel_driver_wrapper/src/carma_novatel_driver_wrapper.cpp
@@ -103,6 +103,9 @@ namespace carma_novatel_driver_wrapper
         
         timer_ = this->create_wall_timer(std::chrono::milliseconds(config_.timer_callback), 
         std::bind(&CarmaNovatelDriverWrapper::timerCallback, this));
+
+        last_gnss_msg_ = this->now();
+        last_imu_msg_ = this->now();
         
         return CallbackReturn::SUCCESS;
     }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR fixes an issue, where an error `Uncaught Exception from node: velodyne_lidar_driver_wrapper_node caught exception: can't subtract times with different time sources [1 != 2] while in unsupported exception handling state: 2` is thrown on launching the node.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Defect fix (non-breaking change that fixes an issue)
- [] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
