### PR TITLE
Move package installations to install.sh

### DIFF
--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -48,7 +48,3 @@ sudo git clone https://github.com/novatel/novatel_oem7_driver.git ${dir}/src/nov
 # Checkout verified commit
 cd ${dir}/src/novatel_oem7_driver
 sudo git checkout 3055e220bb9715b59c3ef53ab0aba05a495d9d5
-
-sudo apt-get update
-sudo apt-get install ros-foxy-nmea-msgs -y
-sudo apt-get install ros-foxy-gps-tools -y

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -33,6 +33,8 @@ if [[ ! -z "$ROS2_PACKAGES" ]]; then
 else
     # Install dependencies
     sudo apt-get update
+    sudo apt-get install ros-foxy-nmea-msgs -y
+    sudo apt-get install ros-foxy-gps-tools -y
     rosdep update
     rosdep install --from-paths src --ignore-src -r -y
     colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR moves the installation of ROS 2 Foxy packages from the checkout.bash script to the install.sh script. 

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->
Fixes #26 

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Image builds locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
