### PR TITLE
Change Novatel Unit communications from TCP to UDP

### DIFF
--- a/carma_novatel_driver_wrapper/launch/carma-novatel-driver-wrapper-launch.py
+++ b/carma_novatel_driver_wrapper/launch/carma-novatel-driver-wrapper-launch.py
@@ -35,7 +35,7 @@ from launch_ros.actions import set_remap
 import os
 
 def generate_launch_description():
-    
+
     # Declare arguments
     log_level = LaunchConfiguration('log_level')
     declare_log_level_arg = DeclareLaunchArgument(
@@ -49,7 +49,7 @@ def generate_launch_description():
 
     vehicle_calibration_dir = LaunchConfiguration('vehicle_calibration_dir')
     declare_vehicle_calibration_dir_arg = DeclareLaunchArgument(
-        name = 'vehicle_calibration_dir', 
+        name = 'vehicle_calibration_dir',
         default_value = "/opt/carma/vehicle/calibration",
         description = "Path to folder containing vehicle calibration directories"
     )
@@ -65,17 +65,17 @@ def generate_launch_description():
 
             IncludeLaunchDescription(
                         PythonLaunchDescriptionSource(['/', novatel_driver_pkg, '/launch','/oem7_net.launch.py']),
-                        launch_arguments={'oem7_ip_addr': ip_addr, 'oem7_port' : port, 'oem7_if': 'Oem7ReceiverTcp'}.items(),
+                        launch_arguments={'oem7_ip_addr': ip_addr, 'oem7_port' : port, 'oem7_if': 'Oem7ReceiverUdp'}.items(),
             )
         ]
     )
 
-    
+
 
     # Add novatel wrapper to carma container
     param_file_path = os.path.join(
         get_package_share_directory('carma_novatel_driver_wrapper'),'config/parameters.yaml')
-    
+
     novatel_wrapper_container = ComposableNodeContainer(
         package = 'carma_ros2_utils',
         name ='carma_novatel_driver_wrapper_container',
@@ -103,7 +103,7 @@ def generate_launch_description():
             declare_vehicle_calibration_dir_arg,
             novatel_params_override_env,
             declare_ip_addr,
-            declare_port, 
+            declare_port,
             novatel_wrapper_container,
             driver_group
         ]


### PR DESCRIPTION
# PR Details
## Description

This PR changes communications between CARMA Platform (Spectra PC) and the Novatel Unit to use UDP instead of TCP. This change is required because the Novatel Unit was often experiencing high CPU usage/spikes and buffer overruns, which resulted in GNSS data not being sent from the Novatel Unit to the Spectra PC. 

@smithjj5 worked with the Novatel team, and the Novatel team recommended that switching to UDP communications will reduce CPU usage in the Novatel unit.

This change requires a corresponding update to the configuration file uploaded directly to the Novatel unit. The required change has been applied to the Novatel units in the Black Pacifica, White Pacifica, Ford Fusion, and Blue Lexus. These configuration files (one for each vehicle) are stored on the Leidos SharePoint internal site: TODO LINK

NOTE: The actual terminal log indicating the Novatel timeout was `carma-novatel-oem7-driver-wrapper  | [carma_component_container_mt-2] 1744843862.821980708 | ERROR | hardware_interface.carma_novatel_driver_wrapper_node | on_error:128 | Uncaught Exception from node: carma_novatel_driver_wrapper_node exception: GPS message wait timed out while in ACTIVE state.`

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
ARC-302

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested on both the White Pacifica and Ford Fusion (two vehicles that had consistent Novatel timeout issues) and worked successfully. CARMA Platform could run for an extended period of time, and multiple tests in automated mode were completed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
